### PR TITLE
Fix some characteristics not being advertised, add IMU sample timestamp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,7 +124,7 @@ void setup() {
 
   // Create the BLE Service
   pService_UART = pServer->createService(SERVICE_UUID_UART);
-  // NOTE: each characteristic wiithingneeds 3 handles, 
+  // NOTE: each characteristic within service needs 3 handles, 
   //       so numHandles = 3 * num characteristics
   pService_IMU = pServer->createService(BLEUUID(SERVICE_UUID_IMU), 21);
   Serial.println("BLE Services created.");


### PR DESCRIPTION
- Six characteristics were created in code but were not visible from an external device through BLE.  
  - The source of this issue was found to be stemming from the number of handles allocated within the IMU Service.  A different createService() override was used to specify the number of handles.  
  - The number of handles can be calculated as: 3 handles per characteristic * number of characteristics per service.
- The IMU values need a timestamp associated with when they were sampled.
  -  A timer and associated characteristic was added to the IMU service, update every time the IMU is sampled.