### PR TITLE
FEAT(): Added command interpreting and WorkoutManager

### DIFF
--- a/include/BluetoothManager.h
+++ b/include/BluetoothManager.h
@@ -7,9 +7,9 @@
 
 // See the following for generating UUIDs:
 // https://www.uuidgenerator.net/
-#define SERVICE_UUID_UART "ac9a41ba-9764-41a6-837f-fc08f2b29d28"
-#define CHARACTERISTIC_UUID_TX "ac9a41ba-9764-41a6-837f-fc08f2b29d28"
-#define CHARACTERISTIC_UUID_RX "ac9a41ba-9764-41a6-837f-fc08f2b29d28"
+#define SERVICE_UUID_UART "bf854c21-e070-446c-9849-305c7188a693"
+#define CHARACTERISTIC_UUID_TX "78628d2b-0008-4d46-b2c4-b755bf2c8c01"
+#define CHARACTERISTIC_UUID_RX "d95dc802-137e-4d13-a3f1-6f384193b7d7"
 #define SERVICE_UUID_IMU "91da3684-137e-4473-8fd2-b112126b19e1"
 #define CHARACTERISTIC_UUID_YAW "694b27b3-7c84-4a7e-a58c-baf08b34cc0c"
 #define CHARACTERISTIC_UUID_PITCH "58499525-a4cf-4bb9-9b16-a6ec73065923"
@@ -46,8 +46,16 @@ void bluetooth_init();
 
 void set_imu_characteristics(BNO08x_RVC_Data *heading);
 
+void set_imu_characteristics();
+
 void handle_disconnect();
 
 void handle_connect();
+
+void set_tx_characteristic(std::string data);
+
+std::string get_rx_data();
+
+void clear_rx_characteristic();
 
 #endif

--- a/include/WorkoutManager.h
+++ b/include/WorkoutManager.h
@@ -1,0 +1,10 @@
+#ifndef WORKOUT_MANAGER_H
+#define WORKOUT_MANAGER_H
+
+extern bool workoutOngoing;
+
+void handle_commands();
+
+void handle_workout();
+
+#endif

--- a/include/board.h
+++ b/include/board.h
@@ -1,0 +1,6 @@
+#ifndef BOARD_H
+#define BOARD_H
+
+#define DEBUG 1
+
+#endif

--- a/src/BluetoothManager.cpp
+++ b/src/BluetoothManager.cpp
@@ -49,13 +49,13 @@ void MyRXCharacteristicCallbacks::onWrite(BLECharacteristic *pCharacteristic)
 
     if (rxValue.length() > 0)
     {
-        Serial.println("*********");
+        Serial.write("*********");
         Serial.print("Received Value: ");
         for (int i = 0; i < rxValue.length(); i++)
             Serial.print(rxValue[i]);
 
-        Serial.println();
-        Serial.println("*********");
+        Serial.write("\n");
+        Serial.write("*********");
     }
 }
 
@@ -63,19 +63,19 @@ void bluetooth_init()
 {
     // Create the BLE Device
     BLEDevice::init(bleServerName);
-    Serial.println("BLE device initialized.");
+    Serial.write("BLE device initialized.\n");
 
     // Create the BLE Server
     pServer = BLEDevice::createServer();
     pServer->setCallbacks(new MyServerCallbacks());
-    Serial.println("BLE Server created, callbacks set.");
+    Serial.write("BLE Server created, callbacks set.\n");
 
     // Create the BLE Service
     pService_UART = pServer->createService(SERVICE_UUID_UART);
     // NOTE: each characteristic within service needs 3 handles,
     //       so numHandles = 3 * num characteristics
     pService_IMU = pServer->createService(BLEUUID(SERVICE_UUID_IMU), 21);
-    Serial.println("BLE Services created.");
+    Serial.write("BLE Services created.\n");
 
     // Create characteristics and add descriptors
     pTxCharacteristic = pService_UART->createCharacteristic(
@@ -132,12 +132,12 @@ void bluetooth_init()
             BLECharacteristic::PROPERTY_READ);
     pTimestampCharacteristic->addDescriptor(new BLE2902);
 
-    Serial.println("BLE characteristics, descriptors, and callbacks set.");
+    Serial.write("BLE characteristics, descriptors, and callbacks set.");
 
     // Start the service
     pService_UART->start();
     pService_IMU->start();
-    Serial.println("BLE Services started.");
+    Serial.write("BLE Services started.\n");
 
     // Start advertising
     pAdvertising = BLEDevice::getAdvertising();
@@ -145,14 +145,14 @@ void bluetooth_init()
     pAdvertising->addServiceUUID(SERVICE_UUID_IMU);
     pServer->getAdvertising()->start();
     advertising = true;
-    Serial.println("BLE advertising started.");
+    Serial.write("BLE advertising started.\n");
 
     // log waiting status
-    Serial.println("Waiting for connection...");
+    Serial.write("Waiting for connection...\n");
 
     // TODO: Make sure this is initializing the timer properly
     Timer1 = timerBegin(1, 2, true);
-    Serial.println("Timer1 started.");
+    Serial.write("Timer1 started.\n");
 }
 
 void set_imu_characteristics(BNO08x_RVC_Data *heading)
@@ -232,7 +232,7 @@ void handle_disconnect()
 {
     delay(500);                  // give the bluetooth stack the chance to get things ready
     pServer->startAdvertising(); // restart advertising
-    Serial.println("Advertising started...");
+    Serial.write("Advertising started...\n");
     advertising = true;
 }
 

--- a/src/IMUManager.cpp
+++ b/src/IMUManager.cpp
@@ -6,7 +6,7 @@ BNO08x_RVC_Data *heading = new BNO08x_RVC_Data();
 
 void imu_init()
 {
-    Serial.println("Adafruit BNO08x IMU - UART-RVC mode");
+    Serial.write("Adafruit BNO08x IMU - UART-RVC mode\n");
 
     // Initialize connect to IMU through serial connection
     Serial1.begin(115200, SERIAL_8N1, 3, 17); // This is the baud rate specified by the datasheet
@@ -18,9 +18,9 @@ void imu_init()
 
     if (!rvc->begin(&Serial1))
     { // connect to the sensor over hardware serial
-        Serial.println("Could not find BNO08x!");
+        Serial.write("Could not find BNO08x!");
         while (1)
             delay(10);
     }
-    Serial.println("BNO08x found!");
+    Serial.write("BNO08x found!\n");
 }

--- a/src/WorkoutManager.cpp
+++ b/src/WorkoutManager.cpp
@@ -1,0 +1,52 @@
+#include "WorkoutManager.h"
+#include <HardwareSerial.h>
+#include "BluetoothManager.h"
+#include "board.h"
+#include "IMUManager.h"
+
+bool workoutOngoing = false;
+
+void handle_commands()
+{
+    std::string rx_data = get_rx_data();
+    if (rx_data.length() > 0)
+    {
+        Serial.println("Received command:");
+        Serial.println(rx_data.c_str());
+        if (rx_data == "start_workout")
+        {
+            Serial.println("Starting workout...");
+            set_tx_characteristic("starting_workout");
+            workoutOngoing = true;
+        }
+        else if (rx_data == "stop_workout")
+        {
+            Serial.println("Stopping workout...");
+            set_tx_characteristic("stopping_workout");
+            workoutOngoing = false;
+        }
+        clear_rx_characteristic();
+    }
+}
+
+void handle_workout()
+{
+    if (workoutOngoing)
+    {
+        if (DEBUG == 1)
+        {
+            set_imu_characteristics();
+        }
+        else
+        {
+            if (!(rvc->read(heading)))
+            {                               // read rvc data
+                Serial.write("Not Read\n"); // indiciate if unsuccessful
+            }
+            else
+            {
+                set_imu_characteristics(heading); // set characteristics to be sent to client
+            }
+        }
+    }
+}

--- a/src/WorkoutManager.cpp
+++ b/src/WorkoutManager.cpp
@@ -11,17 +11,17 @@ void handle_commands()
     std::string rx_data = get_rx_data();
     if (rx_data.length() > 0)
     {
-        Serial.println("Received command:");
-        Serial.println(rx_data.c_str());
+        Serial.write("Received command:\n");
+        Serial.write(rx_data.c_str());
         if (rx_data == "start_workout")
         {
-            Serial.println("Starting workout...");
+            Serial.write("Starting workout...\n");
             set_tx_characteristic("starting_workout");
             workoutOngoing = true;
         }
         else if (rx_data == "stop_workout")
         {
-            Serial.println("Stopping workout...");
+            Serial.write("Stopping workout...\n");
             set_tx_characteristic("stopping_workout");
             workoutOngoing = false;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "SerialManager.h"
 #include "BluetoothManager.h"
 #include "IMUManager.h"
+#include "WorkoutManager.h"
 
 bool interruptCounter = false; // Loop occurs after 100 Hz ISR
 uint8_t txValue = 0;
@@ -28,7 +29,7 @@ void setup()
   serial_init();
 
   // Initialize IMU
-  imu_init();
+  // imu_init();
 
   // Initialize Bluetooth
   bluetooth_init();
@@ -46,23 +47,15 @@ void loop()
 {
 
   // only deal with BLE characteristics when device connected to listen
-  if (deviceConnected)
+  if (interruptCounter)
   {
-    if (interruptCounter)
+    if (deviceConnected)
     {
-
-      if (!(rvc->read(heading)))
-      {                             // read rvc data
-        Serial.write("Not Read\n"); // indiciate if unsuccessful
-      }
-      else
-      {
-
-        set_imu_characteristics(heading); // set characteristics to be sent to client
-
-        interruptCounter = 0; // reset for timer ISR to trigger
-      }
+      handle_workout();  // handle workout data from IMU if workoutOngoing
+      handle_commands(); // handle commands from app
     }
+
+    interruptCounter = 0; // reset for timer ISR to trigger
 
     // incrementally set txValue for testing purposes, then notify
     // pTxCharacteristic->setValue(&txValue, 1);


### PR DESCRIPTION
Despite the branch name, this should not impact original functionality. It adds a board.h file with "DEBUG 1" defined, change it to "DEBUG 0" to get original functionality. 

WorkoutManager handles incoming commands over the UART ble service and handles whether IMU data is being read or not.

Since this does not change the original functionality of the firmware, it will only properly read "IMU data" when in debug mode, in which case dummy data is supplied. Another update would be necessary to add real IMU data transmission to the app, but I am waiting to discuss first. 